### PR TITLE
Moved link time build options out of compile time options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,8 @@ target_compile_options(
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_options(isotp PUBLIC -O0 -g) # don't optimise and add debugging symbols
 else()
-    target_compile_options(isotp PUBLIC -O2 -s) # optimise code and strip the library
+    target_compile_options(isotp PUBLIC -O2) # optimise code
+    target_link_libraries(isotp PUBLIC -s) # strip the library
 endif()
 
 if (isotpc_USE_INCLUDE_DIR)


### PR DESCRIPTION
Moved link time build options out of compile time options

**Issue**
A link time option is set in the compile time options and has no effect, the file is not stripped and remains a larger size.

I ran with cmake version 3.23.1 and compiler GNU 9.4.0

To repeat:
```
mkdir build
cd build
cmake -DCMAKE_BUILD_TYPE=Release ..
make VERBOSE=1
ls -l libisotp.so 
file libisotp.so
```

Current code:
```
-rwxr-xr-x 1 xxxxx xxxxx 16800 Feb  9 12:43 libisotp.so
libisotp.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=bb5eaf2d1b5224dc699c21a17cf76d283f06cbef, not stripped
```

Running after PR change:
```
-rwxr-xr-x 1 xxxxx xxxxx 14472 Feb  9 12:43 libisotp.so
libisotp.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=5d5c9d947e2c6969e47f7ecae5bf1414d9878751, stripped
```
The file is smaller and stripped.

No change for the static library build.

**Other points to note**
The PR used `target_link_libraries` which is available in cmake version 3.10. If you're happy to move the cmake version up to 3.13, `target_link_options` may be better.
https://cmake.org/cmake/help/latest/command/target_link_options.html

This issue was originally noticed when compiling with clang (version 13.0.1) which will fail the build with the following error:
```
[ 50%] Building C object CMakeFiles/isotp.dir/isotp.c.o
clang: error: argument unused during compilation: '-s' [-Werror,-Wunused-command-line-argument]