### PR TITLE
Allow transmissions to be retried if the controller was busy

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ First, create some [shim](https://en.wikipedia.org/wiki/Shim_(computing)) functi
 ```C
     /* required, this must send a single CAN message with the given arbitration
      * ID (i.e. the CAN message ID) and data. The size will never be more than 8
-     * bytes. */
+     * bytes. Should return ISOTP_RET_OK if frame sent successfully.
+     * May return ISOTP_RET_NOSPACE if the frame could not be sent but may be
+     * retried later. Should return ISOTP_RET_ERROR in case frame could not be sent.
+     */
     int  isotp_user_send_can(const uint32_t arbitration_id,
                              const uint8_t* data, const uint8_t size) {
         // ...

--- a/isotp.c
+++ b/isotp.c
@@ -484,6 +484,8 @@ void isotp_poll(IsoTpLink *link) {
                 if (link->send_offset >= link->send_size) {
                     link->send_status = ISOTP_SEND_STATUS_IDLE;
                 }
+            } else if (ISOTP_RET_NOSPACE == ret) {
+                /* shim reported that it isn't able to send a frame at present, retry on next call */
             } else {
                 link->send_status = ISOTP_SEND_STATUS_ERROR;
             }

--- a/isotp_defines.h
+++ b/isotp_defines.h
@@ -42,6 +42,7 @@
 #define ISOTP_RET_NO_DATA      -5
 #define ISOTP_RET_TIMEOUT      -6
 #define ISOTP_RET_LENGTH       -7
+#define ISOTP_RET_NOSPACE      -8
 
 /* return logic true if 'a' is after 'b' */
 #define IsoTpTimeAfter(a,b) ((int32_t)((int32_t)(b) - (int32_t)(a)) < 0)

--- a/isotp_user.h
+++ b/isotp_user.h
@@ -11,6 +11,8 @@ extern "C" {
 void isotp_user_debug(const char* message, ...);
 
 /* user implemented, send can message. should return ISOTP_RET_OK when success.
+** may return ISOTP_RET_NOSPACE if the CAN transfer should be retried later
+** or ISOTP_RET_ERROR if transmission couldn't be completed
 */
 int  isotp_user_send_can(const uint32_t arbitration_id,
                          const uint8_t* data, const uint8_t size);

--- a/isotp_user.h
+++ b/isotp_user.h
@@ -7,17 +7,21 @@
 extern "C" {
 #endif
 
-/* user implemented, print debug message */
+/** @brief user implemented, print debug message */
 void isotp_user_debug(const char* message, ...);
 
-/* user implemented, send can message. should return ISOTP_RET_OK when success.
-** may return ISOTP_RET_NOSPACE if the CAN transfer should be retried later
-** or ISOTP_RET_ERROR if transmission couldn't be completed
-*/
+/**
+ * @brief user implemented, send can message. should return ISOTP_RET_OK when success.
+ * 
+ * @return may return ISOTP_RET_NOSPACE if the CAN transfer should be retried later
+ * or ISOTP_RET_ERROR if transmission couldn't be completed
+ */
 int  isotp_user_send_can(const uint32_t arbitration_id,
                          const uint8_t* data, const uint8_t size);
 
-/* user implemented, get microsecond */
+/**
+ * @brief user implemented, gets the amount of time passed since the last call in microseconds
+ */
 uint32_t isotp_user_get_us(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
While integrating the isotp-c library, we've been calling the poll function as required along with our normal CAN processing.

Our controller has limited internal buffer space (3 frames max I believe).

If during a transmission the host (receiver) requests no flow control, the module will attempt to send a frame on each poll call as expected.

In my original implementation of the send shim I returned error if the transfer couldn't be completed due to a lack of buffer space which would abort the ISO-TP transfer.

This PR adds an additional return value which may be returned from the can send shim, indicating that there is no buffer space. Allowing the module to retry later, rather than aborting the transfer.

In the case of a single frame transfer, the new return value will be passed to the send caller. If they're following the example code and considering anything that's not OK as error they'll see no change. If they require use of the new value, they'll be able to detect that the transfer didn't fail but wasn't able to start.

Flow control frames are a little tricker. The library doesn't check the return value from the shim in this case so no change is required. The remote host will retry at some point in the future where there's hopefully some buffer space available. 