### PR TITLE
Make position independent code flag optional for static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(isotp LANGUAGES C VERSION 1.0.1 DESCRIPTION "A platform-agnostic ISOTP i
 
 option(isotpc_USE_INCLUDE_DIR "Copy header files to separate include directory in current binary dir for better separation of header files to combat potential naming conflicts." OFF)
 option(isotpc_STATIC_LIBRARY "Compile libisotpc as a static library, instead of a shared library." OFF)
+option(isotpc_STATIC_LIBRARY_PIC "Make use of position independent code (PIC), when compiling as a static library (enabled automatically when building shared libraries)." OFF)
 option(isotpc_PAD_CAN_FRAMES "Pad CAN frames to their full size." ON)
 set(isotpc_CAN_FRAME_PAD_VALUE "0xAA" CACHE STRING "Padding byte value to be used in CAN frames if enabled")
 
@@ -20,12 +21,19 @@ endif()
 # Strict building policies
 ###
 target_compile_options(
-    isotp PUBLIC
-    -fPIC
+    isotp PRIVATE
     -Werror
     -Wall
     -Wno-unknown-pragmas # ignore unknown pragmas, such as #pragma region
 )
+
+###
+# Enable position independent code (PIC) if required
+###
+if (NOT isotpc_STATIC_LIBRARY OR isotpc_STATIC_LIBRARY_PIC)
+    # Building a shared library or a static library with PIC enabled
+    target_compile_options(isotp PRIVATE -fPIC)
+endif()
 
 ###
 # Provide padding configuration
@@ -38,10 +46,10 @@ endif()
 # Check for debug builds
 ###
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    target_compile_options(isotp PUBLIC -O0 -g) # don't optimise and add debugging symbols
+    target_compile_options(isotp PRIVATE -O0 -g) # don't optimise and add debugging symbols
 else()
-    target_compile_options(isotp PUBLIC -O2) # optimise code
-    target_link_libraries(isotp PUBLIC -s) # strip the library
+    target_compile_options(isotp PRIVATE -O2) # optimise code
+    target_link_libraries(isotp PRIVATE -s) # strip the library
 endif()
 
 if (isotpc_USE_INCLUDE_DIR)

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ If your projects use a different build system, you are more than welcome to incl
 
 The Makefile generator for isotpc will automatically detect whether or not your build system is using the `Debug` or `Release` build type and will adjust compiler parameters accordingly.
 
-> **NOTE**: Regardless of build type, the library will be compiled as position-independant code.
-
 #### Debug Build
 If your project is configured to build as `Debug`, then the library will be compiled with **no** optimisations and **with** debug symbols.  
 `-DCMAKE_BUILD_TYPE=Debug`

--- a/isotp_config.h
+++ b/isotp_config.h
@@ -23,7 +23,7 @@
 
 /* Private: Determines if by default, padding is added to ISO-TP message frames.
  */
-//#define ISO_TP_FRAME_PADDING 0xAA
+//#define ISO_TP_FRAME_PADDING
 
 /* Private: Value to use when padding frames if enabled by ISO_TP_FRAME_PADDING
  */


### PR DESCRIPTION
Have updated compile options to be private rather than public.

Have added a new cmake option, allowing the PIC argument to be included when building a static library. 

It's set to OFF by default, such that shared libraries will build with PIC enabled and static without.

Have removed the banner from the README indicating that PIC is always enabled.

Have snuck in a correction to the isotp_config.h file. I meant to keep the ISO_TP_FRAME_PADDING line for reference. But forgot to remove the 0xAA from the end of the line, which may lead to future confusion. I can split this out if you'd prefer.