### PR TITLE
Make on_can_message data pointer const

### DIFF
--- a/isotp.c
+++ b/isotp.c
@@ -278,7 +278,7 @@ int isotp_send_with_id(IsoTpLink *link, uint32_t id, const uint8_t payload[], ui
     return ret;
 }
 
-void isotp_on_can_message(IsoTpLink *link, uint8_t *data, uint8_t len) {
+void isotp_on_can_message(IsoTpLink *link, const uint8_t *data, uint8_t len) {
     IsoTpCanMessage message;
     int ret;
     

--- a/isotp.h
+++ b/isotp.h
@@ -84,7 +84,7 @@ void isotp_poll(IsoTpLink *link);
  * @param data The data received via CAN.
  * @param len The length of the data received.
  */
-void isotp_on_can_message(IsoTpLink *link, uint8_t *data, uint8_t len);
+void isotp_on_can_message(IsoTpLink *link, const uint8_t *data, uint8_t len);
 
 /**
  * @brief Sends ISO-TP frames via CAN, using the ID set in the initialising function.


### PR DESCRIPTION
Me again...tiny one this time.

Spotted by a college while reviewing my integration.

The on_can_message call doesn't have a need to modify the data buffer, therefore the pointer to it can be made const.