### PR TITLE
Cast unused function args to void

### DIFF
--- a/isotp.c
+++ b/isotp.c
@@ -213,6 +213,10 @@ static int isotp_receive_consecutive_frame(IsoTpLink *link, IsoTpCanMessage *mes
 }
 
 static int isotp_receive_flow_control_frame(IsoTpLink *link, IsoTpCanMessage *message, uint8_t len) {
+    /* unused args */
+    (void) link;
+    (void) message;
+
     /* check message length */
     if (len < 3) {
         isotp_user_debug("Flow control frame too short.");


### PR DESCRIPTION
Cast unused function parameters to void.

**Issue**
There are GCC warnings raised about unused function parameters when an extra option is turned on

The warning can be raised with `-Wextra` or `-Wunused-parameter`

To repeat:
```
# Add extra warning check
sed -i 's/-Wall/-Wall\n -Wunused-parameter/g' CMakeLists.txt
mkdir build
cd build
cmake ..
make
```

Current code fails with the following error (raised from a warning):
```
[ 50%] Building C object CMakeFiles/isotp.dir/isotp.c.o
/home/speedy-h/isotp-c/isotp.c: In function ‘isotp_receive_flow_control_frame’:
/home/speedy-h/isotp-c/isotp.c:215:56: error: unused parameter ‘link’ [-Werror=unused-parameter]
  215 | static int isotp_receive_flow_control_frame(IsoTpLink *link, IsoTpCanMessage *message, uint8_t len) {
      |                                             ~~~~~~~~~~~^~~~
/home/speedy-h/isotp-c/isotp.c:215:79: error: unused parameter ‘message’ [-Werror=unused-parameter]
  215 | static int isotp_receive_flow_control_frame(IsoTpLink *link, IsoTpCanMessage *message, uint8_t len) {
      |                                                              ~~~~~~~~~~~~~~~~~^~~~~~~
cc1: all warnings being treated as errors
```

Running after PR change leads to a successful build with the additional warning covered.

I opted to cast the function parameters to void rather than change the function prototype to keep in line with the other `isotp_receive_*` functions accepting the same arguments.\
The other option would be to use the `unused` attribute. But I think the void cast is more common.
