### PR TITLE
PlatformIO library descriptor

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@
 | [Phil Greenland](https://github.com/pgreenland)     |  Added support for message retries if the remote controller was busy                           | #26    |
 | [Phil Greenland](https://github.com/pgreenland)     |  Fixed PIC being generated for static binaries                                                 | #27    |
 | [speedy-h](https://github.com/speedy-h)             |  Fixed compiler error when compiling with `-Wextra` caused by unused function params.          | #32    |
+| [kazetsukaimiko](https://github.com/kazetsukaimiko) |  Added support for PlatformIO, a platform for distributing libraries for a variety of systems. | #35    |
 
 Thank you everyone for contributing to this library and improving it!
 Have you contributed and I've forgotten to mention you? Please let me know and I'll add you here!

--- a/library.json
+++ b/library.json
@@ -1,5 +1,5 @@
 {
-  "name": "iso-tp",
+  "name": "isotp-c",
   "version": "v1.1.2",
   "description": "ISO 15765-2 Support Library in C",
   "keywords": "c,windows,linux,c-plus-plus,arm,multi-platform,microcontroller,embedded,mips,can,x86,ppc,powerpc,uds,embedded-c,controller-area-network,iso-tp,unified-diagnostics-services,iso-15765-2,15765-2",

--- a/library.json
+++ b/library.json
@@ -1,5 +1,5 @@
 {
-  "name": "ISO-TP",
+  "name": "iso-tp",
   "version": "v1.1.2",
   "description": "ISO 15765-2 Support Library in C",
   "keywords": "c,windows,linux,c-plus-plus,arm,multi-platform,microcontroller,embedded,mips,can,x86,ppc,powerpc,uds,embedded-c,controller-area-network,iso-tp,unified-diagnostics-services,iso-15765-2,15765-2",

--- a/library.json
+++ b/library.json
@@ -1,0 +1,22 @@
+{
+  "name": "ISO-TP",
+  "version": "v1.1.2",
+  "description": "ISO 15765-2 Support Library in C",
+  "keywords": "c,windows,linux,c-plus-plus,arm,multi-platform,microcontroller,embedded,mips,can,x86,ppc,powerpc,uds,embedded-c,controller-area-network,iso-tp,unified-diagnostics-services,iso-15765-2,15765-2",
+  "authors": {
+    "name": "SimonCahill",
+    "url": "https://github.com/SimonCahill/isotp-c",
+    "maintainer": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:SimonCahill/isotp-c.git"
+  },
+  "version": "1.1.7",
+  "frameworks": "*",
+  "platforms": "*",
+  "headers": "isotp.h",
+  "build": {
+    "libArchive": false
+  }
+}

--- a/library.json
+++ b/library.json
@@ -12,7 +12,6 @@
     "type": "git",
     "url": "git@github.com:SimonCahill/isotp-c.git"
   },
-  "version": "1.1.7",
   "frameworks": "*",
   "platforms": "*",
   "headers": "isotp.h",


### PR DESCRIPTION
This adds a PlatformIO library descriptor so that embedded / IoT developers can include iso-tp in their projects using PlatformIO dependency management. 

[What is PlatformIO?](https://docs.platformio.org/en/latest/what-is-platformio.html)
*"PlatformIO is a cross-platform, cross-architecture, multiple framework, professional tool for embedded systems engineers and for software developers who write applications for embedded products."*

It can be referenced in `platformio.ini` either by repo url:
```ini
[env]
platform = espressif32
framework = arduino
lib_deps = 
	https://github.com/SimonCahill/isotp-c.git#v1.1.2
```

Or you can [publish](https://docs.platformio.org/en/latest/librarymanager/creating.html) the library to the [PlatformIO Registry](https://platformio.org/lib) and reference it by name / version:

```ini
[env]
platform = espressif32
framework = arduino
lib_deps = 
	SimonCahill/isotp-c @ v1.1.2
```

See the [Dependencies](https://docs.platformio.org/en/latest/librarymanager/dependencies.html) page for best practices.

Tested on my fork using a branch name reference:
```ini
[env]
platform = espressif32
framework = arduino
lib_deps = 
	https://github.com/kazetsukaimiko/isotp-c.git#platformio-library-registration
```
