### PR TITLE
add option ISO_TP_USER_SEND_CAN_ARG 

### DIFF
--- a/.github/workflows/build-w-opt-can-arg.yml
+++ b/.github/workflows/build-w-opt-can-arg.yml
@@ -1,4 +1,4 @@
-name: CMake
+name: "CMake w/ changes from #36"
 
 on:
   push:

--- a/.github/workflows/build-w-opt-can-arg.yml
+++ b/.github/workflows/build-w-opt-can-arg.yml
@@ -1,0 +1,40 @@
+name: CMake
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Checkout Submodules
+      run: git submodule update --init --recursive
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -Disotp_ENABLE_CAN_SEND_ARG=ON
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{env.BUILD_TYPE}}
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(isotpc_STATIC_LIBRARY "Compile libisotpc as a static library, instead of 
 option(isotpc_STATIC_LIBRARY_PIC "Make use of position independent code (PIC), when compiling as a static library (enabled automatically when building shared libraries)." OFF)
 option(isotpc_PAD_CAN_FRAMES "Pad CAN frames to their full size." ON)
 set(isotpc_CAN_FRAME_PAD_VALUE "0xAA" CACHE STRING "Padding byte value to be used in CAN frames if enabled")
+option(isotpc_ENABLE_CAN_SEND_ARG "Adds an extra argument to isotp_user_send_can to better support multiple CAN interfaces." OFF)
 
 if (isotpc_STATIC_LIBRARY)
     add_library(isotp STATIC ${CMAKE_CURRENT_SOURCE_DIR}/isotp.c)
@@ -40,6 +41,13 @@ endif()
 ###
 if (isotpc_PAD_CAN_FRAMES)
     target_compile_definitions(isotp PRIVATE -DISO_TP_FRAME_PADDING -DISO_TP_FRAME_PADDING_VALUE=${isotpc_CAN_FRAME_PAD_VALUE})
+endif()
+
+###
+# Include additional arg in isotp_user_send_can if required
+###
+if (isotpc_ENABLE_CAN_SEND_ARG)
+    target_compile_options(isotp PRIVATE -DISO_TP_USER_SEND_CAN_ARG)
 endif()
 
 ###

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 ###
 # Project definition
 ###
-project(isotp LANGUAGES C VERSION 1.1.1 DESCRIPTION "A platform-agnostic ISOTP implementation in C for embedded devices.")
+project(isotp LANGUAGES C VERSION 1.2.0 DESCRIPTION "A platform-agnostic ISOTP implementation in C for embedded devices.")
 
 option(isotpc_USE_INCLUDE_DIR "Copy header files to separate include directory in current binary dir for better separation of header files to combat potential naming conflicts." OFF)
 option(isotpc_STATIC_LIBRARY "Compile libisotpc as a static library, instead of a shared library." OFF)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@
 | [Phil Greenland](https://github.com/pgreenland)     |  Fixed PIC being generated for static binaries                                                 | #27    |
 | [speedy-h](https://github.com/speedy-h)             |  Fixed compiler error when compiling with `-Wextra` caused by unused function params.          | #32    |
 | [kazetsukaimiko](https://github.com/kazetsukaimiko) |  Added support for PlatformIO, a platform for distributing libraries for a variety of systems. | #35    |
+| [driftregion](https://github.com/driftregion)       |  Added support for optional CAN arguments for adapter-specific information.                    | #36    |
 
 Thank you everyone for contributing to this library and improving it!
 Have you contributed and I've forgotten to mention you? Please let me know and I'll add you here!

--- a/README.md
+++ b/README.md
@@ -76,6 +76,46 @@ isotp-c supports this also, via options.
 
 Either pass `-Disotpc_STATIC_LIBRARY=ON` via command-line or `set(isotpc_STATIC_LIBRARY ON CACHE BOOL "Enable static library for isotp-c")` in your CMakeLists.txt and the library will be built as a static library (`*.a|*.lib`) for your project to include.
 
+#### Use of multiple CAN interfaces
+For applications requiring multiple CAN interfaces, it is necessary to specify the interface in `isotp_user_send_can`. 
+
+In this case the config option `-DISO_TP_USER_SEND_CAN_ARG` may be enabled. The library may then be used as follows:
+
+```c
+// Objects representing two CAN interfaces: a and b.
+CAN_IFACE_t can_a, can_b;
+
+void init() {
+    // Two IsoTpLinks assumed to be bound to different CAN interfaces.
+    IsoTpLink link_a, link_b;
+
+    isotp_init_link(&link_a, ...);
+    isotp_init_link(&link_b, ...);
+
+    // After link initialization, the relevant CAN interface may be
+    // attached to the link. 
+    link_a.user_send_can_arg = &can_a;
+    link_a.user_send_can_arg = &can_b;
+}
+
+int isotp_user_send_can(
+    const uint32_t arbitration_id, 
+    const uint8_t *data, 
+    const uint8_t size,
+    void *user_send_can_arg) 
+{
+    // It is then available for use inside isotp_user_send_can
+    int err = CAN_SEND((CAN_IFACE_t *)(user_send_can_arg), arbitration_id, data, size);
+    if (err) {
+        return ISOTP_RET_ERROR;
+    } else {
+        return ISOTP_RET_OK;
+    }
+}
+
+```
+
+
 #### Inclusion in your CMake project
 ```cmake
 ###

--- a/isotp.h
+++ b/isotp.h
@@ -53,6 +53,10 @@ typedef struct IsoTpLink {
                                                      end at receive FC */
     int                         receive_protocol_result;
     uint8_t                     receive_status;                                                     
+
+#if defined(ISO_TP_USER_SEND_CAN_ARG)
+    void*                       user_send_can_arg;
+#endif
 } IsoTpLink;
 
 /**

--- a/isotp_config.h
+++ b/isotp_config.h
@@ -31,5 +31,10 @@
 #define ISO_TP_FRAME_PADDING_VALUE 0xAA
 #endif
 
+/* Private: Determines if by default, an additional argument is present in the
+ * definition of isotp_user_send_can. 
+ */
+//#define ISO_TP_USER_SEND_CAN_ARG
+
 #endif
 

--- a/isotp_user.h
+++ b/isotp_user.h
@@ -17,7 +17,11 @@ void isotp_user_debug(const char* message, ...);
  * or ISOTP_RET_ERROR if transmission couldn't be completed
  */
 int  isotp_user_send_can(const uint32_t arbitration_id,
-                         const uint8_t* data, const uint8_t size);
+                         const uint8_t* data, const uint8_t size
+#if ISO_TP_USER_SEND_CAN_ARG
+,void *arg
+#endif                         
+                         );
 
 /**
  * @brief user implemented, gets the amount of time passed since the last call in microseconds

--- a/vars.mk
+++ b/vars.mk
@@ -31,8 +31,8 @@ CPPSTD := "c++0x"
 ###
 LIB_NAME := "libisotp.so"
 MAJOR_VER := "1"
-MINOR_VER := "1"
-REVISION := "1"
+MINOR_VER := "2"
+REVISION := "0"
 OUTPUT_NAME := $(LIB_NAME).$(MAJOR_VER).$(MINOR_VER).$(REVISION)
 
 ###


### PR DESCRIPTION
add option ISO_TP_USER_SEND_CAN_ARG  which includes an additional void* argument in isotp_user_send_can with which to pass adapter-specific information.