### PR TITLE
Fix snprintf format specifier for cross-platform compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 ###
 # Project definition
 ###
-project(isotp LANGUAGES C VERSION 1.2.0 DESCRIPTION "A platform-agnostic ISOTP implementation in C for embedded devices.")
+project(isotp LANGUAGES C VERSION 1.2.1 DESCRIPTION "A platform-agnostic ISOTP implementation in C for embedded devices.")
 
 option(isotpc_USE_INCLUDE_DIR "Copy header files to separate include directory in current binary dir for better separation of header files to combat potential naming conflicts." OFF)
 option(isotpc_STATIC_LIBRARY "Compile libisotpc as a static library, instead of a shared library." OFF)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@
 | [kazetsukaimiko](https://github.com/kazetsukaimiko) |  Added support for PlatformIO, a platform for distributing libraries for a variety of systems. | #35    |
 | [driftregion](https://github.com/driftregion)       |  Added support for optional CAN arguments for adapter-specific information.                    | #36    |
 | [andyneubacher](https://github.com/AndyNeubacher)   |  Added support for larger frame sizes (ISO15765-2:2016).                                       | #46    |
+| [mws262](https://github.com/mws262)                 |  Fixed snprintf format string for embedded devices (replaced %d w/ %u)                         | #47    |
 
 Thank you everyone for contributing to this library and improving it!
 Have you contributed and I've forgotten to mention you? Please let me know and I'll add you here!

--- a/isotp.c
+++ b/isotp.c
@@ -311,7 +311,7 @@ int isotp_send_with_id(IsoTpLink *link, uint32_t id, const uint8_t payload[], ui
         isotp_user_debug("Message size too large. Increase ISO_TP_MAX_MESSAGE_SIZE to set a larger buffer\n");
         const int32_t messageSize = 128;
         char message[messageSize];
-        int32_t writtenChars = snprintf(&message[0], 128, "Attempted to send %d bytes; max size is %d!\n", size, link->send_buf_size);
+        int32_t writtenChars = snprintf(&message[0], 128, "Attempted to send %u  bytes; max size is %u!\n", (unsigned int)size, (unsigned int)link->send_buf_size);
 
         assert(writtenChars <= messageSize);
         (void) writtenChars;

--- a/vars.mk
+++ b/vars.mk
@@ -32,7 +32,7 @@ CPPSTD := "c++0x"
 LIB_NAME := "libisotp.so"
 MAJOR_VER := "1"
 MINOR_VER := "2"
-REVISION := "0"
+REVISION := "1"
 OUTPUT_NAME := $(LIB_NAME).$(MAJOR_VER).$(MINOR_VER).$(REVISION)
 
 ###


### PR DESCRIPTION
This PR resolves a cross-platform compatibility issue caused by differing type definitions for uint32_t.

On some architectures (e.g., ESP32), uint32_t is defined as unsigned long, causing format errors when using %u. On others (e.g., x86_64 Linux), it matches unsigned int.

The fix explicitly casts these variables to (unsigned int) to match %u.