### PR TITLE
feat: make config options overridable

### DIFF
--- a/isotp_config.h
+++ b/isotp_config.h
@@ -17,22 +17,30 @@
 /* Max number of messages the receiver can receive at one time, this value
  * is affected by can driver queue length
  */
-#define ISO_TP_DEFAULT_BLOCK_SIZE 8
+#ifndef ISO_TP_DEFAULT_BLOCK_SIZE
+    #define ISO_TP_DEFAULT_BLOCK_SIZE 8
+#endif
 
 /* The STmin parameter value specifies the minimum time gap allowed between
  * the transmission of consecutive frame network protocol data units
  */
-#define ISO_TP_DEFAULT_ST_MIN_US 0
+#ifndef ISO_TP_DEFAULT_ST_MIN_US
+    #define ISO_TP_DEFAULT_ST_MIN_US 0
+#endif
 
 /* This parameter indicate how many FC N_PDU WTs can be transmitted by the
  * receiver in a row.
  */
-#define ISO_TP_MAX_WFT_NUMBER 1
+#ifndef ISO_TP_MAX_WFT_NUMBER
+    #define ISO_TP_MAX_WFT_NUMBER 1
+#endif
 
 /* Private: The default timeout to use when waiting for a response during a
  * multi-frame send or receive.
  */
-#define ISO_TP_DEFAULT_RESPONSE_TIMEOUT_US 100000
+#ifndef ISO_TP_DEFAULT_RESPONSE_TIMEOUT_US
+    #define ISO_TP_DEFAULT_RESPONSE_TIMEOUT_US 100000
+#endif
 
 /* Private: Determines if by default, padding is added to ISO-TP message frames.
  */


### PR DESCRIPTION
This PR makes the different config options overridable. This is useful for projects that, for example, require a larger `ISO_TP_DEFAULT_BLOCK_SIZE` but want to avoid patching the library directly.

Similar to the existing overridable option [ISO_TP_FRAME_PADDING_VALUE](https://github.com/SimonCahill/isotp-c/blob/083709f57d8fc964e7ac5dd0c7ac7aef6364f156/isotp_config.h#L43-L45), the other config options can now be overridden using `#define` macros before including the library, or by setting compiler flags.