### PR TITLE
Don't propagate link option to dependents

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_standard:
     name: Build with MSVC via CMake
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - name: Check out repository
@@ -30,7 +30,7 @@ jobs:
   
   build_w_custom_can_arg:
     name: Build with MSVC via CMake; enabled user-CAN-arg
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - name: Check out repository
@@ -52,7 +52,7 @@ jobs:
   
   build_standard_w_events:
     name: Build with MSVC via CMake
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - name: Check out repository
@@ -75,7 +75,7 @@ jobs:
   
   build_w_custom_can_arg_w_events:
     name: Build with MSVC via CMake; enabled user-CAN-arg
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - name: Check out repository

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_options(isotp PRIVATE -O0 -g) # don't optimise and add debugging symbols
 else()
     target_compile_options(isotp PRIVATE -O2) # optimise code
-    target_link_libraries(isotp PRIVATE -s) # strip the library
+    target_link_options(isotp PRIVATE -s) # strip the library
 endif()
 
 if (isotpc_USE_INCLUDE_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,9 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_options(isotp PRIVATE -O0 -g) # don't optimise and add debugging symbols
 else()
     target_compile_options(isotp PRIVATE -O2) # optimise code
-    target_link_options(isotp PRIVATE -s) # strip the library
+    if (NOT isotpc_STATIC_LIBRARY AND NOT MSVC)
+        target_link_libraries(isotp PRIVATE -s) # strip the library
+    endif()
 endif()
 
 if (isotpc_USE_INCLUDE_DIR)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@
 | [mws262](https://github.com/mws262)                 |  Fixed snprintf format string for embedded devices (replaced %d w/ %u)                         | #47    |
 | [eternal-echo](https://github.com/eternal-echo)     |  Fixed minor issues with conditional compilation regarding user-args to can_send.              | #50    |
 | [markxoe](https://github.com/markxoe)               |  ISOTP settings are now configurable at build time.                                            | #54    |
+| [speedy-h](https://github.com/speedy-h)             |  Don't propagate link option to dependents                                                     | #63    |
 
 Thank you everyone for contributing to this library and improving it!
 Have you contributed and I've forgotten to mention you? Please let me know and I'll add you here!


### PR DESCRIPTION
Stop propagating the link option to dependents when building the static library.

**Issue**

When using the static library in a project with a non _Debug_ type build, the link option to strip the library is propagated to the executable. This was noticed when during a _RelWithDebInfo_ build where the debug symbols are wanted (at least for the executable source files, if not the library).

Run the below script on master to see the issue with a dummy demo executable to show what link command CMake will use.

```sh
# Create demo application
echo 'int main(void) { return 0; }' > demo.c

# Append executable to CMake build
echo '' >> CMakeLists.txt
echo 'add_executable(demo demo.c)' >> CMakeLists.txt
echo 'target_link_libraries(demo PRIVATE isotp)' >> CMakeLists.txt

# Set up CMake files
mkdir build_static
cd build_static
cmake -Disotpc_STATIC_LIBRARY=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo ..

# See what gets stripped
grep -- ' -s' CMakeFiles/isotp.dir/link.txt # Expect no output
grep -- ' -s' CMakeFiles/demo.dir/link.txt # Expect no output, but get output!

# Build the shared library
cd ..
mkdir build_shared
cd build_shared
cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .. # Shared library is the default

# See what gets stripped
grep -- ' -s' CMakeFiles/isotp.dir/link.txt # Expect something like 'libisotp.so -s'
grep -- ' -s' CMakeFiles/demo.dir/link.txt # Expect no output
```

As can be seen in the `grep` outputs, the shared library behaves as wanted, but the executable with the static library doesn't.

Running the above after the PR changes shows no change to the shared library link commands. The static build has no `-s` option in either link command, as wanted.

The CMake documentation states that the link flags get propagated as normal and so are generally safe when PRIVATE. This isn't true for static libraries build because there is no link step. Instead the option is applied at the dependent’s link step. Excluding it for static (and Windows) builds seems to work

https://cmake.org/cmake/help/latest/command/target_link_libraries.html

> **A link flag**: Item names starting with `-`, but not `-l` or `-framework`, are treated as linker flags. Note that such flags will be treated like any other library link item for purposes of transitive dependencies, so they are generally safe to specify only as private link items that will not propagate to dependents.

An alternative to excluding the strip option via an if statement is to use `target_link_options`, as it doesn't have this _transitive-on-static_ issue. This option was introduced in CMake 3.13 and is why this isn't used.

https://cmake.org/cmake/help/latest/command/target_link_options.html

> **Note** This command cannot be used to add options for static library targets, since they do not use a linker. To add archiver or MSVC librarian flags, see the STATIC_LIBRARY_OPTIONS target property.