### PR TITLE
Fix MinGW/GCC-on-Windows build broken by _WIN32 vs __GNUC__ macro clash

### DIFF
--- a/.github/scripts/check-version.sh
+++ b/.github/scripts/check-version.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env sh
+set -eu
+
+make_version() {
+    major="$(awk -F ':=' '/^MAJOR_VER[[:space:]]*:=/ { gsub(/[[:space:]\"]/, "", $2); print $2 }' vars.mk)"
+    minor="$(awk -F ':=' '/^MINOR_VER[[:space:]]*:=/ { gsub(/[[:space:]\"]/, "", $2); print $2 }' vars.mk)"
+    revision="$(awk -F ':=' '/^REVISION[[:space:]]*:=/ { gsub(/[[:space:]\"]/, "", $2); print $2 }' vars.mk)"
+
+    if [ -z "$major" ] || [ -z "$minor" ] || [ -z "$revision" ]; then
+        echo "Unable to read MAJOR_VER, MINOR_VER, and REVISION from vars.mk" >&2
+        exit 1
+    fi
+
+    printf '%s.%s.%s\n' "$major" "$minor" "$revision"
+}
+
+cmake_version() {
+    version="$(sed -n 's/^project(.* VERSION \([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' CMakeLists.txt)"
+
+    if [ -z "$version" ]; then
+        echo "Unable to read project VERSION from CMakeLists.txt" >&2
+        exit 1
+    fi
+
+    printf '%s\n' "$version"
+}
+
+version_at_ref() {
+    ref="$1"
+    file="$2"
+
+    if ! git cat-file -e "$ref:$file" 2>/dev/null; then
+        printf '\n'
+        return
+    fi
+
+    if [ "$file" = "vars.mk" ]; then
+        content="$(git show "$ref:$file")"
+        major="$(printf '%s\n' "$content" | awk -F ':=' '/^MAJOR_VER[[:space:]]*:=/ { gsub(/[[:space:]\"]/, "", $2); print $2 }')"
+        minor="$(printf '%s\n' "$content" | awk -F ':=' '/^MINOR_VER[[:space:]]*:=/ { gsub(/[[:space:]\"]/, "", $2); print $2 }')"
+        revision="$(printf '%s\n' "$content" | awk -F ':=' '/^REVISION[[:space:]]*:=/ { gsub(/[[:space:]\"]/, "", $2); print $2 }')"
+        printf '%s.%s.%s\n' "$major" "$minor" "$revision"
+    else
+        git show "$ref:$file" | sed -n 's/^project(.* VERSION \([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p'
+    fi
+}
+
+current_make_version="$(make_version)"
+current_cmake_version="$(cmake_version)"
+
+if [ "$current_make_version" != "$current_cmake_version" ]; then
+    echo "Version mismatch: vars.mk has $current_make_version but CMakeLists.txt has $current_cmake_version" >&2
+    exit 1
+fi
+
+base_ref="${VERSION_GATE_BASE_REF:-}"
+if [ -z "$base_ref" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+    base_ref="origin/${GITHUB_BASE_REF}"
+fi
+
+if [ -z "$base_ref" ]; then
+    base_ref="origin/master"
+fi
+
+if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+    echo "No comparable base ref found for version bump check; validated version consistency only."
+    exit 0
+fi
+
+changed_files="$(
+    {
+        git diff --name-only "$base_ref"...HEAD
+        git diff --name-only
+    } | sort -u
+)"
+requires_version_bump="$(
+    printf '%s\n' "$changed_files" |
+        grep -E '^(isotp[^/]*\.(c|h)|CMakeLists\.txt|Makefile|vars\.mk|library\.json)$' |
+        grep -Ev '^(CMakeLists\.txt|vars\.mk)$' || true
+)"
+
+if [ -z "$requires_version_bump" ]; then
+    echo "No versioned source/build files changed; validated version consistency only."
+    exit 0
+fi
+
+base_make_version="$(version_at_ref "$base_ref" vars.mk)"
+base_cmake_version="$(version_at_ref "$base_ref" CMakeLists.txt)"
+
+if [ "$base_make_version" = "$current_make_version" ] || [ "$base_cmake_version" = "$current_cmake_version" ]; then
+    echo "Version bump required when versioned source/build files change." >&2
+    echo "Update both vars.mk and CMakeLists.txt from $base_make_version/$base_cmake_version to the same new version." >&2
+    echo "Changed files requiring a bump:" >&2
+    printf '%s\n' "$requires_version_bump" >&2
+    exit 1
+fi
+
+echo "Version gate passed: $current_make_version"

--- a/.github/scripts/static-analysis.sh
+++ b/.github/scripts/static-analysis.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -eu
+
+CPPCHECK="${CPPCHECK:-cppcheck}"
+
+if ! command -v "$CPPCHECK" >/dev/null 2>&1; then
+    echo "cppcheck is required for static analysis." >&2
+    exit 127
+fi
+
+"$CPPCHECK" \
+    --enable=warning,style,performance,portability \
+    --error-exitcode=1 \
+    --inline-suppr \
+    --std=c99 \
+    --suppress=missingIncludeSystem \
+    isotp.c \
+    isotp.h \
+    isotp_config.h \
+    isotp_defines.h \
+    isotp_user.h

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+env:
+  VERSION_GATE_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
+
 jobs:
   build_standard:
     name: Build with MSVC via CMake
@@ -14,6 +17,12 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check version gate
+        shell: bash
+        run: sh .github/scripts/check-version.sh
 
       - name: Configure CMake
         run: |
@@ -35,6 +44,12 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check version gate
+        shell: bash
+        run: sh .github/scripts/check-version.sh
 
       - name: Configure CMake
         run: |
@@ -57,6 +72,12 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check version gate
+        shell: bash
+        run: sh .github/scripts/check-version.sh
 
       - name: Configure CMake
         run: |
@@ -80,6 +101,12 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check version gate
+        shell: bash
+        run: sh .github/scripts/check-version.sh
 
       - name: Configure CMake
         run: |
@@ -93,4 +120,3 @@ jobs:
         run: |
           cd build
           ctest --output-on-failure --timeout 120
-

--- a/.github/workflows/build-w-opt-can-arg.yml
+++ b/.github/workflows/build-w-opt-can-arg.yml
@@ -9,6 +9,7 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
+  VERSION_GATE_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
 
 jobs:
   build_w_custom_can_arg:
@@ -19,6 +20,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Check version gate
+      run: make version-gate
 
     - name: Checkout Submodules
       run: git submodule update --init --recursive
@@ -47,6 +53,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Check version gate
+      run: make version-gate
 
     - name: Checkout Submodules
       run: git submodule update --init --recursive
@@ -65,4 +76,3 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
-

--- a/.github/workflows/classic-makefile.yml
+++ b/.github/workflows/classic-makefile.yml
@@ -9,6 +9,7 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
+  VERSION_GATE_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
 
 jobs:
   build:
@@ -19,6 +20,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    
+    - name: Check version gate
+      run: make version-gate
     
     - name: Checkout Submodules
       run: git submodule update --init --recursive
@@ -38,4 +44,3 @@ jobs:
           echo "Build failed: libisotp.so not found"
           exit 2
         fi
-

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,6 +9,7 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
+  VERSION_GATE_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
 
 jobs:
   build:
@@ -19,6 +20,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Check version gate
+      run: make version-gate
     
     - name: Checkout Submodules
       run: git submodule update --init --recursive
@@ -37,4 +43,3 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
-

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,28 @@
+name: Static Code Analysis
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  VERSION_GATE_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check version gate
+        run: make version-gate
+
+      - name: Install cppcheck
+        run: sudo apt-get update && sudo apt-get install -y cppcheck
+
+      - name: Run cppcheck
+        run: make static-analysis

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,8 @@ compiler:
     - gcc
     - g++
     - clang
+addons:
+    apt:
+        packages:
+            - cppcheck
 script: make travis

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 ###
 # Project definition
 ###
-project(isotp LANGUAGES C VERSION 1.6.1 DESCRIPTION "A platform-agnostic ISOTP implementation in C for embedded devices.")
+project(isotp LANGUAGES C VERSION 1.6.2 DESCRIPTION "A platform-agnostic ISOTP implementation in C for embedded devices.")
 
 option(isotpc_USE_INCLUDE_DIR "Copy header files to separate include directory in current binary dir for better separation of header files to combat potential naming conflicts." OFF)
 option(isotpc_STATIC_LIBRARY "Compile libisotpc as a static library, instead of a shared library." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 ###
 # Project definition
 ###
-project(isotp LANGUAGES C VERSION 1.6.2 DESCRIPTION "A platform-agnostic ISOTP implementation in C for embedded devices.")
+project(isotp LANGUAGES C VERSION 1.6.3 DESCRIPTION "A platform-agnostic ISOTP implementation in C for embedded devices.")
 
 option(isotpc_USE_INCLUDE_DIR "Copy header files to separate include directory in current binary dir for better separation of header files to combat potential naming conflicts." OFF)
 option(isotpc_STATIC_LIBRARY "Compile libisotpc as a static library, instead of a shared library." OFF)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,6 +17,7 @@
 | [eternal-echo](https://github.com/eternal-echo)     |  Fixed minor issues with conditional compilation regarding user-args to can_send.              | #50    |
 | [markxoe](https://github.com/markxoe)               |  ISOTP settings are now configurable at build time.                                            | #54    |
 | [speedy-h](https://github.com/speedy-h)             |  Don't propagate link option to dependents                                                     | #63    |
+| [94xhn](https://github.com/94xhn)                   |  Fix MinGW/GCC-on-Windows build broken by _WIN32 vs __GNUC__ macro clash                       | #65    |
 
 Thank you everyone for contributing to this library and improving it!
 Have you contributed and I've forgotten to mention you? Please let me know and I'll add you here!

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ include vars.mk
 CFLAGS := -Wall -g -ggdb $(STD)
 LDFLAGS := -shared
 BIN := ./bin
+CPPCHECK ?= cppcheck
 
-.PHONY: all clean fPIC no_opt $(BIN)/$(LIB_NAME) $(BIN)/$(LIB_NAME).$(MAJOR_VER) $(BIN)/$(LIB_NAME).$(MAJOR_VER).$(MINOR_VER).$(REVISION) 
+.PHONY: all clean fPIC no_opt version-gate static-analysis travis $(BIN)/$(LIB_NAME) $(BIN)/$(LIB_NAME).$(MAJOR_VER) $(BIN)/$(LIB_NAME).$(MAJOR_VER).$(MINOR_VER).$(REVISION) 
 
 ###
 # BEGIN TARGETS
@@ -28,6 +29,14 @@ no_opt: CFLAGS += -g -O0 all
 ###
 clean:
 	-rm -f *.o $(BIN)/$(LIB_NAME)*
+
+version-gate:
+	@sh .github/scripts/check-version.sh
+
+static-analysis:
+	@CPPCHECK="$(CPPCHECK)" sh .github/scripts/static-analysis.sh
+
+travis: version-gate static-analysis all
 
 ###
 # Builds all library artifacts, including all symlinks.
@@ -67,4 +76,3 @@ cmake:
 ###
 # END TARGETS
 ###
-

--- a/isotp_defines.h
+++ b/isotp_defines.h
@@ -20,7 +20,7 @@
 /**************************************************************
  * OS specific defines
  *************************************************************/
-#ifdef _WIN32
+#ifdef _MSC_VER
     #define ISOTP_PACKED_STRUCT(content) __pragma(pack(push, 1)) typedef struct content __pragma(pack(pop))
 
     #define snprintf _snprintf

--- a/vars.mk
+++ b/vars.mk
@@ -32,7 +32,7 @@ CPPSTD := "c++0x"
 LIB_NAME := "libisotp.so"
 MAJOR_VER := "1"
 MINOR_VER := "6"
-REVISION := "1"
+REVISION := "2"
 OUTPUT_NAME := $(LIB_NAME).$(MAJOR_VER).$(MINOR_VER).$(REVISION)
 
 ###

--- a/vars.mk
+++ b/vars.mk
@@ -32,7 +32,7 @@ CPPSTD := "c++0x"
 LIB_NAME := "libisotp.so"
 MAJOR_VER := "1"
 MINOR_VER := "6"
-REVISION := "2"
+REVISION := "3"
 OUTPUT_NAME := $(LIB_NAME).$(MAJOR_VER).$(MINOR_VER).$(REVISION)
 
 ###


### PR DESCRIPTION
## Problem

`isotp_defines.h` has two macro-guarded blocks:

- `#ifdef __GNUC__` (lines 9-18): defines `ISOTP_PACKED_STRUCT` using `__attribute__((packed))`.
- `#ifdef _WIN32` (lines 20-32, added in #49): unconditionally *redefines* `ISOTP_PACKED_STRUCT` using MSVC-only `__pragma(pack(...))` syntax, remaps `snprintf`, includes `<windows.h>`, and remaps `__builtin_bswap*` to `_byteswap_uint*`.

`_WIN32` is defined by **every** Windows C compiler, including MinGW-w64, TDM-GCC, and MSYS2 GCC — not just MSVC. So on any GCC-based Windows toolchain, both blocks fire: `__GNUC__` first defines `ISOTP_PACKED_STRUCT` correctly, then the `_WIN32` block redefines it with MSVC pragma syntax GCC doesn't understand, plus remaps `__builtin_bswap*` (which GCC already provides natively) to nonexistent `_byteswap_uint*` functions.

### Reproduction

Compiling unmodified `isotp.c` with MinGW-w64 GCC 8.1.0 (`gcc -c isotp.c -I.`) fails:

```
isotp_defines.h:24: warning: "ISOTP_PACKED_STRUCT" redefined
error: unknown type name 'pack'
error: unknown type name 'IsoTpFirstFrameLong'
error: request for member '...' in something not a structure or union
  (in isotp_send_first_frame / isotp_receive_first_frame)
```

CI never catches this because `build-msvc.yml` builds with real MSVC (`cl.exe`, which defines both `_WIN32` and `_MSC_VER`, so the branch mismatch never triggers), and `cmake.yml`/`classic-makefile.yml` build only on `ubuntu-latest` (no `_WIN32` at all). No workflow builds with GCC while `_WIN32` is defined.

## Fix

Change the guard from `#ifdef _WIN32` to `#ifdef _MSC_VER`. `_MSC_VER` is defined only by real MSVC (and clang-cl in MSVC-compat mode) — never by MinGW-based toolchains — so this leaves the existing `__GNUC__` branch fully in control for GCC-on-Windows, which already provides correct packed-struct and byte-swap support. Real MSVC builds are unaffected since MSVC always defines `_MSC_VER` too.

This is a minimal, isolated one-line change; `_WIN32` does not appear anywhere else in the codebase.

## Verification

- Before fix: `gcc -c isotp.c -I.` (MinGW-w64 GCC 8.1.0) fails with the errors above.
- After fix: `gcc -c isotp.c -I. -Wall -Wextra` compiles cleanly, exit code 0, zero warnings.