### PR TITLE
Added support for streaming files as per #60.

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -S . -B build  -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
+          cmake -S . -B build  -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -Disotpc_ENABLE_TESTING=ON
 
       - name: Build (Release)
         run: cmake --build build --config Release -- /m
@@ -35,7 +35,7 @@ jobs:
         if: always()
         run: |
           cd build
-          ctest --output-on-failure --timeout 120
+          ctest -C Release --output-on-failure --timeout 120
   
   build_w_custom_can_arg:
     name: Build with MSVC via CMake; enabled user-CAN-arg

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -Disotpc_ENABLE_TESTING=ON
 
     - name: Build
       # Build your program with the given configuration
@@ -42,4 +42,4 @@ jobs:
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ option(isotpc_ENABLE_TRANSCEIVE_EVENTS "Enable events/callbacks for transmission
 option(isotpc_ENABLE_TRANSMIT_COMPLETE_CALLBACK "Enable transmit complete callback." ON) # These can be disabled separately, as they are controlled by the main event option
 option(isotpc_ENABLE_RECEIVE_COMPLETE_CALLBACK "Enable receive complete callback." ON) # These can be disabled separately, as they are controlled by the main event option
 option(isotpc_ENABLE_STREAMING "Enable chunked reception of messages larger than the receive buffer." OFF)
-# option(isotpc_ENABLE_TESTING "Enable building of test suite." OFF)
+option(isotpc_ENABLE_TESTING "Enable building of test suite." OFF)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -120,7 +120,7 @@ add_library(simon_cahill::isotp_c ALIAS isotp)
 ###
 # Enable testing
 ###
-# if (isotpc_ENABLE_TESTING)
-#     enable_testing()
-#     add_subdirectory(test)
-# endif()
+if (isotpc_ENABLE_TESTING)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 ###
 # Project definition
 ###
-project(isotp LANGUAGES C VERSION 1.6.4 DESCRIPTION "A platform-agnostic ISOTP implementation in C for embedded devices.")
+project(isotp LANGUAGES C VERSION 1.7.0 DESCRIPTION "A platform-agnostic ISOTP implementation in C for embedded devices.")
 
 option(isotpc_USE_INCLUDE_DIR "Copy header files to separate include directory in current binary dir for better separation of header files to combat potential naming conflicts." OFF)
 option(isotpc_STATIC_LIBRARY "Compile libisotpc as a static library, instead of a shared library." OFF)
@@ -14,6 +14,7 @@ option(isotpc_ENABLE_CAN_SEND_ARG "Adds an extra argument to isotp_user_send_can
 option(isotpc_ENABLE_TRANSCEIVE_EVENTS "Enable events/callbacks for transmission and reception complete." OFF)
 option(isotpc_ENABLE_TRANSMIT_COMPLETE_CALLBACK "Enable transmit complete callback." ON) # These can be disabled separately, as they are controlled by the main event option
 option(isotpc_ENABLE_RECEIVE_COMPLETE_CALLBACK "Enable receive complete callback." ON) # These can be disabled separately, as they are controlled by the main event option
+option(isotpc_ENABLE_STREAMING "Enable chunked reception of messages larger than the receive buffer." OFF)
 # option(isotpc_ENABLE_TESTING "Enable building of test suite." OFF)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -77,6 +78,10 @@ if (isotpc_ENABLE_TRANSCEIVE_EVENTS)
     if (isotpc_ENABLE_RECEIVE_COMPLETE_CALLBACK)
         target_compile_definitions(isotp PRIVATE -DISO_TP_RECEIVE_COMPLETE_CALLBACK)
     endif()
+endif()
+
+if (isotpc_ENABLE_STREAMING)
+    target_compile_definitions(isotp PUBLIC -DISO_TP_ENABLE_STREAMING)
 endif()
 
 ###

--- a/README.md
+++ b/README.md
@@ -253,6 +253,39 @@ You can use isotp-c in the following way:
 You can call isotp_poll as frequently as you want, as it internally uses isotp_user_get_ms to measure timeout occurences.
 If you need handle functional addressing, you must use two separate links, one for each.
 
+#### Streaming receive mode (optional)
+
+Enable `isotpc_ENABLE_STREAMING` to receive a message larger than the link's
+receive buffer without allocating space for the complete message:
+
+```cmake
+set(isotpc_ENABLE_STREAMING ON CACHE BOOL "Enable chunked ISO-TP reception")
+```
+
+Call `isotp_receive_streaming()` in the same polling loop used for
+`isotp_receive()`. Each successful call returns the next chunk. The library
+uses flow control to pause the sender whenever the internal receive buffer is
+full, and resumes reception after the application consumes that chunk.
+
+```C
+bool message_complete;
+uint32_t chunk_size;
+
+ret = isotp_receive_streaming(&g_link, chunk, sizeof(chunk),
+                              &chunk_size, &message_complete);
+if (ret == ISOTP_RET_OK) {
+    write_chunk_to_flash(chunk, chunk_size);
+    if (message_complete) {
+        finish_update();
+    }
+}
+```
+
+When building without CMake, define `ISO_TP_ENABLE_STREAMING` in
+`isotp_config.h`. The feature is disabled by default and does not change the
+link structure or public API unless enabled. Oversized messages use the
+streaming polling API even when receive callbacks are configured.
+
 ```C
     /* Alloc IsoTpLink statically in RAM */
     static IsoTpLink g_phylink;

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ If your projects use a different build system, you are more than welcome to incl
 
 The Makefile generator for isotpc will automatically detect whether or not your build system is using the `Debug` or `Release` build type and will adjust compiler parameters accordingly.
 
+#### Unit tests
+
+The unit suite includes mocked CAN transmission, timing, debugging, and
+receive-callback shims. Enable it with CMake and run it through CTest:
+
+```bash
+cmake -S . -B build -Disotpc_ENABLE_TESTING=ON
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+The streaming test subject enables streaming and receive callbacks
+independently of the options used for the normal library target.
+
 #### Debug Build
 If your project is configured to build as `Debug`, then the library will be compiled with **no** optimisations and **with** debug symbols.  
 `-DCMAKE_BUILD_TYPE=Debug`

--- a/isotp.c
+++ b/isotp.c
@@ -210,13 +210,22 @@ static int isotp_receive_single_frame(IsoTpLink* link, const IsoTpCanMessage* me
     /* copying data */
     (void)memcpy(link->receive_buffer, message->as.single_frame.data, message->as.single_frame.SF_DL);
     link->receive_size = message->as.single_frame.SF_DL;
+    link->receive_offset = link->receive_size;
+
+#ifdef ISO_TP_ENABLE_STREAMING
+    link->receive_stream_size       = link->receive_size;
+    link->receive_streaming         = 0;
+    link->receive_stream_carry_size = 0;
+#endif
 
     return ISOTP_RET_OK;
 }
 
 static int isotp_receive_first_frame(IsoTpLink* link, IsoTpCanMessage* message, uint8_t len) {
-    uint8_t  is_long_packet = 0;
-    uint32_t payload_length;
+    const uint8_t* first_frame_data;
+    uint8_t        is_long_packet = 0;
+    uint32_t       first_frame_data_length;
+    uint32_t       payload_length;
 
     if (8 != len) {
         isotp_user_debug("First frame should be 8 bytes in length.");
@@ -239,22 +248,48 @@ static int isotp_receive_first_frame(IsoTpLink* link, IsoTpCanMessage* message, 
         return ISOTP_RET_LENGTH;
     }
 
+#ifndef ISO_TP_ENABLE_STREAMING
     if (payload_length > link->receive_buf_size) {
         isotp_user_debug("Multi-frame response too large for receiving buffer.");
         return ISOTP_RET_OVERFLOW;
     }
+#else
+    if (link->receive_buf_size == 0) {
+        isotp_user_debug("Receiving buffer must not be empty.");
+        return ISOTP_RET_OVERFLOW;
+    }
+
+    link->receive_streaming         = payload_length > link->receive_buf_size;
+    link->receive_stream_size       = 0;
+    link->receive_stream_carry_size = 0;
+#endif
 
     /* copying data */
     if (is_long_packet) {
-        (void)memcpy(link->receive_buffer, message->as.first_frame_long.data, sizeof(message->as.first_frame_long.data));
-        link->receive_offset = sizeof(message->as.first_frame_long.data);
+        first_frame_data        = message->as.first_frame_long.data;
+        first_frame_data_length = sizeof(message->as.first_frame_long.data);
     } else {
-        (void)memcpy(link->receive_buffer, message->as.first_frame_short.data, sizeof(message->as.first_frame_short.data));
-        link->receive_offset = sizeof(message->as.first_frame_short.data);
+        first_frame_data        = message->as.first_frame_short.data;
+        first_frame_data_length = sizeof(message->as.first_frame_short.data);
     }
 
-    link->receive_size = payload_length;
-    link->receive_sn   = 1;
+#ifdef ISO_TP_ENABLE_STREAMING
+    if (first_frame_data_length > link->receive_buf_size) {
+        (void)memcpy(link->receive_buffer, first_frame_data, link->receive_buf_size);
+        link->receive_stream_size       = link->receive_buf_size;
+        link->receive_stream_carry_size = (uint8_t)(first_frame_data_length - link->receive_buf_size);
+        (void)memcpy(link->receive_stream_carry, first_frame_data + link->receive_buf_size, link->receive_stream_carry_size);
+    } else {
+        (void)memcpy(link->receive_buffer, first_frame_data, first_frame_data_length);
+        link->receive_stream_size = first_frame_data_length;
+    }
+#else
+    (void)memcpy(link->receive_buffer, first_frame_data, first_frame_data_length);
+#endif
+
+    link->receive_offset = first_frame_data_length;
+    link->receive_size   = payload_length;
+    link->receive_sn     = 1;
 
     return ISOTP_RET_OK;
 }
@@ -273,8 +308,24 @@ static int isotp_receive_consecutive_frame(IsoTpLink* link, const IsoTpCanMessag
         return ISOTP_RET_LENGTH;
     }
 
-    /* copying data */
-    (void)memcpy(link->receive_buffer + link->receive_offset, message->as.consecutive_frame.data, remaining_bytes);
+#ifdef ISO_TP_ENABLE_STREAMING
+    if (link->receive_streaming) {
+        uint32_t available = link->receive_buf_size - link->receive_stream_size;
+        uint32_t copy_size = remaining_bytes < available ? remaining_bytes : available;
+
+        (void)memcpy(link->receive_buffer + link->receive_stream_size, message->as.consecutive_frame.data, copy_size);
+        link->receive_stream_size += copy_size;
+
+        link->receive_stream_carry_size = (uint8_t)(remaining_bytes - copy_size);
+        if (link->receive_stream_carry_size > 0) {
+            (void)memcpy(link->receive_stream_carry, message->as.consecutive_frame.data + copy_size, link->receive_stream_carry_size);
+        }
+    } else
+#endif
+    {
+        /* copying data */
+        (void)memcpy(link->receive_buffer + link->receive_offset, message->as.consecutive_frame.data, remaining_bytes);
+    }
 
     link->receive_offset += remaining_bytes;
     if (++(link->receive_sn) > 0x0F) { link->receive_sn = 0; }
@@ -410,11 +461,20 @@ void isotp_on_can_message(IsoTpLink* link, const uint8_t* data, uint8_t len) {
 
             /* if receive successful */
             if (ISOTP_RET_OK == ret) {
-                /* change status */
-                link->receive_status = ISOTP_RECEIVE_STATUS_INPROGRESS;
-                /* send fc frame */
+                /* change status and send fc frame */
+#ifdef ISO_TP_ENABLE_STREAMING
+                if (link->receive_streaming && link->receive_stream_size >= link->receive_buf_size) {
+                    link->receive_status = ISOTP_RECEIVE_STATUS_FULL;
+                } else {
+                    link->receive_status = ISOTP_RECEIVE_STATUS_INPROGRESS;
+                    link->receive_bs_count = link->receive_streaming ? 1 : ISO_TP_DEFAULT_BLOCK_SIZE;
+                    isotp_send_flow_control(link, PCI_FLOW_STATUS_CONTINUE, link->receive_bs_count, ISO_TP_DEFAULT_ST_MIN_US);
+                }
+#else
+                link->receive_status   = ISOTP_RECEIVE_STATUS_INPROGRESS;
                 link->receive_bs_count = ISO_TP_DEFAULT_BLOCK_SIZE;
                 isotp_send_flow_control(link, PCI_FLOW_STATUS_CONTINUE, link->receive_bs_count, ISO_TP_DEFAULT_ST_MIN_US);
+#endif
                 /* refresh timer cs */
                 link->receive_timer_cr = isotp_user_get_us() + ISO_TP_DEFAULT_RESPONSE_TIMEOUT_US;
             }
@@ -444,12 +504,20 @@ void isotp_on_can_message(IsoTpLink* link, const uint8_t* data, uint8_t len) {
                 link->receive_timer_cr = isotp_user_get_us() + ISO_TP_DEFAULT_RESPONSE_TIMEOUT_US;
 
                 /* receive finished */
-                if (link->receive_offset >= link->receive_size) {
+                if (link->receive_offset >= link->receive_size
+#ifdef ISO_TP_ENABLE_STREAMING
+                    || (link->receive_streaming && link->receive_stream_size >= link->receive_buf_size)
+#endif
+                ) {
                     link->receive_status = ISOTP_RECEIVE_STATUS_FULL;
                 } else {
                     /* send fc when bs reaches limit */
                     if (0 == --link->receive_bs_count) {
-                        link->receive_bs_count = ISO_TP_DEFAULT_BLOCK_SIZE;
+                        link->receive_bs_count =
+#ifdef ISO_TP_ENABLE_STREAMING
+                            link->receive_streaming ? 1 :
+#endif
+                            ISO_TP_DEFAULT_BLOCK_SIZE;
                         isotp_send_flow_control(link, PCI_FLOW_STATUS_CONTINUE, link->receive_bs_count, ISO_TP_DEFAULT_ST_MIN_US);
                     }
                 }
@@ -504,7 +572,11 @@ void isotp_on_can_message(IsoTpLink* link, const uint8_t* data, uint8_t len) {
 
 #ifdef ISO_TP_RECEIVE_COMPLETE_CALLBACK
     /* Notify user via callback if registered */
-    if (link->receive_status == ISOTP_RECEIVE_STATUS_FULL && link->rx_done_cb != NULL) {
+    if (link->receive_status == ISOTP_RECEIVE_STATUS_FULL && link->rx_done_cb != NULL
+#ifdef ISO_TP_ENABLE_STREAMING
+        && !link->receive_streaming
+#endif
+    ) {
         link->rx_done_cb(link, link->receive_buffer, link->receive_size, link->rx_done_cb_arg);
         link->receive_status = ISOTP_RECEIVE_STATUS_IDLE;
     }
@@ -520,6 +592,10 @@ int isotp_receive(IsoTpLink* link, uint8_t* payload, const uint32_t payload_size
     if (link->rx_done_cb != NULL) { return ISOTP_RET_ERROR; /* Callback mode active, use callback instead */ }
 #endif
 
+#ifdef ISO_TP_ENABLE_STREAMING
+    if (link->receive_streaming) { return ISOTP_RET_ERROR; }
+#endif
+
     if (ISOTP_RECEIVE_STATUS_FULL != link->receive_status) { return ISOTP_RET_NO_DATA; }
 
     copylen = link->receive_size;
@@ -532,6 +608,51 @@ int isotp_receive(IsoTpLink* link, uint8_t* payload, const uint32_t payload_size
 
     return ISOTP_RET_OK;
 }
+
+#ifdef ISO_TP_ENABLE_STREAMING
+int isotp_receive_streaming(IsoTpLink* link, uint8_t* payload, const uint32_t payload_size, uint32_t* out_size, bool* is_complete) {
+    uint32_t copylen;
+
+    if (link == NULL || payload == NULL || out_size == NULL || is_complete == NULL) { return ISOTP_RET_ERROR; }
+    if (ISOTP_RECEIVE_STATUS_FULL != link->receive_status) { return ISOTP_RET_NO_DATA; }
+
+    copylen = link->receive_streaming ? link->receive_stream_size : link->receive_size;
+    if (payload_size < copylen) { return ISOTP_RET_NOSPACE; }
+
+    (void)memcpy(payload, link->receive_buffer, copylen);
+    *out_size    = copylen;
+    *is_complete = link->receive_offset >= link->receive_size && link->receive_stream_carry_size == 0;
+
+    if (!link->receive_streaming || *is_complete) {
+        link->receive_status    = ISOTP_RECEIVE_STATUS_IDLE;
+        link->receive_streaming = 0;
+        return ISOTP_RET_OK;
+    }
+
+    link->receive_stream_size = link->receive_stream_carry_size;
+    if (link->receive_stream_size > link->receive_buf_size) {
+        link->receive_stream_size = link->receive_buf_size;
+    }
+    if (link->receive_stream_size > 0) {
+        (void)memcpy(link->receive_buffer, link->receive_stream_carry, link->receive_stream_size);
+        link->receive_stream_carry_size -= (uint8_t)link->receive_stream_size;
+        if (link->receive_stream_carry_size > 0) {
+            (void)memmove(link->receive_stream_carry, link->receive_stream_carry + link->receive_stream_size, link->receive_stream_carry_size);
+        }
+    }
+
+    if (link->receive_stream_carry_size > 0 || link->receive_offset >= link->receive_size) {
+        link->receive_status = ISOTP_RECEIVE_STATUS_FULL;
+    } else {
+        link->receive_status   = ISOTP_RECEIVE_STATUS_INPROGRESS;
+        link->receive_bs_count = 1;
+        isotp_send_flow_control(link, PCI_FLOW_STATUS_CONTINUE, link->receive_bs_count, ISO_TP_DEFAULT_ST_MIN_US);
+        link->receive_timer_cr = isotp_user_get_us() + ISO_TP_DEFAULT_RESPONSE_TIMEOUT_US;
+    }
+
+    return ISOTP_RET_OK;
+}
+#endif
 
 void isotp_init_link(IsoTpLink* link, uint32_t sendid, uint8_t* sendbuf, uint32_t sendbufsize, uint8_t* recvbuf, uint32_t recvbufsize) {
     memset(link, 0, sizeof(*link));

--- a/isotp.h
+++ b/isotp.h
@@ -10,6 +10,7 @@
 #define ISOTPC_H
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <string.h>
 
 #ifdef __cplusplus
@@ -66,6 +67,13 @@ typedef struct IsoTpLink {
                                     end at receive FC */
     int                 receive_protocol_result;
     uint8_t             receive_status;
+
+#ifdef ISO_TP_ENABLE_STREAMING
+    uint32_t            receive_stream_size; /* Bytes currently available in receive_buffer */
+    uint8_t             receive_streaming;   /* The current message is larger than receive_buffer */
+    uint8_t             receive_stream_carry_size;
+    uint8_t             receive_stream_carry[7]; /* Remainder of a CF crossing a chunk boundary */
+#endif
 
 #if defined(ISO_TP_USER_SEND_CAN_ARG)
     void*               user_send_can_arg;
@@ -154,6 +162,28 @@ int isotp_send_with_id(IsoTpLink* link, uint32_t id, const uint8_t payload[], ui
  *      - @link ISOTP_RET_NO_DATA @endlink
  */
 int isotp_receive(IsoTpLink* link, uint8_t* payload, const uint32_t payload_size, uint32_t* out_size);
+
+#ifdef ISO_TP_ENABLE_STREAMING
+/**
+ * @brief Receives the next available chunk of an ISO-TP message.
+ *
+ * When an incoming multi-frame message is larger than the link's receive
+ * buffer, reception is paused using ISO-TP flow control whenever that buffer
+ * is full. Calling this function consumes the buffered chunk and allows the
+ * sender to continue. The function may also be used for messages which fit in
+ * the receive buffer.
+ *
+ * @param link The @link IsoTpLink @endlink instance used to receive data.
+ * @param payload Destination for the available chunk.
+ * @param payload_size Size of the destination buffer.
+ * @param out_size Receives the number of bytes copied to @p payload.
+ * @param is_complete Set to true when the returned chunk ends the message.
+ *
+ * @return @link ISOTP_RET_OK @endlink, @link ISOTP_RET_NO_DATA @endlink,
+ *         @link ISOTP_RET_NOSPACE @endlink, or @link ISOTP_RET_ERROR @endlink.
+ */
+int isotp_receive_streaming(IsoTpLink* link, uint8_t* payload, const uint32_t payload_size, uint32_t* out_size, bool* is_complete);
+#endif
 
 #ifdef ISO_TP_TRANSMIT_COMPLETE_CALLBACK
 /**

--- a/isotp_config.h
+++ b/isotp_config.h
@@ -63,4 +63,9 @@
 /* Enable support for receive complete callback */
 // #define ISO_TP_RECEIVE_COMPLETE_CALLBACK
 
+/* Enable support for receiving messages larger than the receive buffer in
+ * application-consumable chunks.
+ */
+// #define ISO_TP_ENABLE_STREAMING
+
 #endif // ISOTPC_CONFIG_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,40 @@
+add_library(isotp_streaming_test_subject STATIC
+    ${PROJECT_SOURCE_DIR}/isotp.c
+)
+
+target_include_directories(isotp_streaming_test_subject PUBLIC
+    ${PROJECT_SOURCE_DIR}
+)
+
+target_compile_definitions(isotp_streaming_test_subject PUBLIC
+    ISO_TP_ENABLE_STREAMING
+    ISO_TP_FRAME_PADDING
+    ISO_TP_RECEIVE_COMPLETE_CALLBACK
+)
+
+add_executable(isotp_streaming_tests
+    test_streaming.c
+    mocks/isotp_user_mock.c
+)
+
+target_include_directories(isotp_streaming_tests PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(isotp_streaming_tests PRIVATE
+    isotp_streaming_test_subject
+)
+
+if (MSVC)
+    target_compile_options(isotp_streaming_test_subject PRIVATE /W4)
+    target_compile_options(isotp_streaming_tests PRIVATE /W4)
+else()
+    target_compile_options(isotp_streaming_test_subject PRIVATE
+        -Werror -Wall -Wpedantic -Wextra -Wno-unknown-pragmas
+    )
+    target_compile_options(isotp_streaming_tests PRIVATE
+        -Werror -Wall -Wpedantic -Wextra
+    )
+endif()
+
+add_test(NAME isotp_streaming_tests COMMAND isotp_streaming_tests)

--- a/tests/mocks/isotp_user_mock.c
+++ b/tests/mocks/isotp_user_mock.c
@@ -1,0 +1,80 @@
+#include "mocks/isotp_user_mock.h"
+
+#include <stdarg.h>
+#include <string.h>
+
+static IsoTpMockCanFrame can_frames[ISOTP_MOCK_MAX_CAN_FRAMES];
+static size_t can_frame_count;
+static size_t debug_count;
+static uint32_t current_time_us;
+
+static size_t rx_callback_count;
+static uint8_t rx_callback_data[ISOTP_MOCK_MAX_CALLBACK_DATA];
+static uint32_t rx_callback_size;
+static void* rx_callback_link;
+static void* rx_callback_arg;
+
+void isotp_mock_reset(void) {
+    (void)memset(can_frames, 0, sizeof(can_frames));
+    can_frame_count = 0;
+    debug_count = 0;
+    current_time_us = 0;
+
+    rx_callback_count = 0;
+    (void)memset(rx_callback_data, 0, sizeof(rx_callback_data));
+    rx_callback_size = 0;
+    rx_callback_link = NULL;
+    rx_callback_arg = NULL;
+}
+
+void isotp_mock_set_time_us(uint32_t time_us) { current_time_us = time_us; }
+
+void isotp_mock_advance_time_us(uint32_t elapsed_us) { current_time_us += elapsed_us; }
+
+size_t isotp_mock_can_frame_count(void) { return can_frame_count; }
+
+const IsoTpMockCanFrame* isotp_mock_can_frame(size_t index) {
+    if (index >= can_frame_count) { return NULL; }
+    return &can_frames[index];
+}
+
+size_t isotp_mock_debug_count(void) { return debug_count; }
+
+void isotp_user_debug(const char* message, ...) {
+    (void)message;
+    ++debug_count;
+}
+
+int isotp_user_send_can(const uint32_t arbitration_id, const uint8_t* data, const uint8_t size) {
+    IsoTpMockCanFrame* frame;
+
+    if (can_frame_count >= ISOTP_MOCK_MAX_CAN_FRAMES || size > sizeof(can_frames[0].data)) { return ISOTP_RET_NOSPACE; }
+
+    frame = &can_frames[can_frame_count++];
+    frame->arbitration_id = arbitration_id;
+    frame->size = size;
+    (void)memcpy(frame->data, data, size);
+    return ISOTP_RET_OK;
+}
+
+uint32_t isotp_user_get_us(void) { return current_time_us; }
+
+void isotp_mock_rx_done_cb(void* link, const uint8_t* data, uint32_t size, void* user_arg) {
+    ++rx_callback_count;
+    rx_callback_link = link;
+    rx_callback_arg = user_arg;
+    rx_callback_size = size;
+
+    if (size > sizeof(rx_callback_data)) { size = sizeof(rx_callback_data); }
+    (void)memcpy(rx_callback_data, data, size);
+}
+
+size_t isotp_mock_rx_callback_count(void) { return rx_callback_count; }
+
+const uint8_t* isotp_mock_rx_callback_data(void) { return rx_callback_data; }
+
+uint32_t isotp_mock_rx_callback_size(void) { return rx_callback_size; }
+
+void* isotp_mock_rx_callback_link(void) { return rx_callback_link; }
+
+void* isotp_mock_rx_callback_arg(void) { return rx_callback_arg; }

--- a/tests/mocks/isotp_user_mock.h
+++ b/tests/mocks/isotp_user_mock.h
@@ -1,0 +1,33 @@
+#ifndef ISOTP_USER_MOCK_H
+#define ISOTP_USER_MOCK_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "isotp.h"
+
+#define ISOTP_MOCK_MAX_CAN_FRAMES 2048u
+#define ISOTP_MOCK_MAX_CALLBACK_DATA 8192u
+
+typedef struct IsoTpMockCanFrame {
+    uint32_t arbitration_id;
+    uint8_t data[8];
+    uint8_t size;
+} IsoTpMockCanFrame;
+
+void isotp_mock_reset(void);
+void isotp_mock_set_time_us(uint32_t time_us);
+void isotp_mock_advance_time_us(uint32_t elapsed_us);
+
+size_t isotp_mock_can_frame_count(void);
+const IsoTpMockCanFrame* isotp_mock_can_frame(size_t index);
+size_t isotp_mock_debug_count(void);
+
+void isotp_mock_rx_done_cb(void* link, const uint8_t* data, uint32_t size, void* user_arg);
+size_t isotp_mock_rx_callback_count(void);
+const uint8_t* isotp_mock_rx_callback_data(void);
+uint32_t isotp_mock_rx_callback_size(void);
+void* isotp_mock_rx_callback_link(void);
+void* isotp_mock_rx_callback_arg(void);
+
+#endif

--- a/tests/test_streaming.c
+++ b/tests/test_streaming.c
@@ -1,0 +1,438 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "isotp.h"
+#include "mocks/isotp_user_mock.h"
+
+#define TEST_OUTPUT_CAPACITY 8192u
+#define TEST_CHUNK_CAPACITY 1024u
+
+#define CHECK(condition)                                                                                                                \
+    do {                                                                                                                                \
+        if (!(condition)) {                                                                                                             \
+            (void)fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, __LINE__, #condition);                                       \
+            return 1;                                                                                                                   \
+        }                                                                                                                               \
+    } while (0)
+
+typedef struct TestLink {
+    IsoTpLink link;
+    uint8_t send_buffer[8];
+    uint8_t receive_buffer[64];
+} TestLink;
+
+typedef struct StreamResult {
+    uint8_t output[TEST_OUTPUT_CAPACITY];
+    uint32_t output_size;
+    uint32_t chunk_sizes[TEST_CHUNK_CAPACITY];
+    size_t chunk_count;
+    size_t complete_count;
+} StreamResult;
+
+static void fill_payload(uint8_t* payload, uint32_t size) {
+    uint32_t index;
+
+    for (index = 0; index < size; ++index) { payload[index] = (uint8_t)((index * 37u + 11u) & 0xffu); }
+}
+
+static void init_test_link(TestLink* test_link, uint32_t receive_buffer_size) {
+    isotp_mock_reset();
+    (void)memset(test_link, 0, sizeof(*test_link));
+    isotp_init_link(&test_link->link, 0x731, test_link->send_buffer, sizeof(test_link->send_buffer), test_link->receive_buffer, receive_buffer_size);
+}
+
+static uint32_t inject_first_frame(IsoTpLink* link, const uint8_t* payload, uint32_t payload_size) {
+    uint8_t frame[8] = {0};
+    uint32_t data_size;
+
+    if (payload_size <= 4095u) {
+        frame[0] = (uint8_t)(0x10u | (payload_size >> 8));
+        frame[1] = (uint8_t)payload_size;
+        data_size = 6;
+        (void)memcpy(frame + 2, payload, data_size);
+    } else {
+        frame[0] = 0x10;
+        frame[1] = 0;
+        frame[2] = (uint8_t)(payload_size >> 24);
+        frame[3] = (uint8_t)(payload_size >> 16);
+        frame[4] = (uint8_t)(payload_size >> 8);
+        frame[5] = (uint8_t)payload_size;
+        data_size = 2;
+        (void)memcpy(frame + 6, payload, data_size);
+    }
+
+    isotp_on_can_message(link, frame, sizeof(frame));
+    return data_size;
+}
+
+static void inject_consecutive_frame(IsoTpLink* link, const uint8_t* payload, uint32_t payload_size, uint32_t* offset, uint8_t* sequence_number) {
+    uint8_t frame[8] = {0};
+    uint32_t data_size = payload_size - *offset;
+
+    if (data_size > 7u) { data_size = 7; }
+    frame[0] = (uint8_t)(0x20u | *sequence_number);
+    (void)memcpy(frame + 1, payload + *offset, data_size);
+    isotp_on_can_message(link, frame, (uint8_t)(data_size + 1u));
+
+    *offset += data_size;
+    *sequence_number = (uint8_t)((*sequence_number + 1u) & 0x0fu);
+}
+
+static int drain_available_chunks(IsoTpLink* link, StreamResult* result) {
+    while (link->receive_status == ISOTP_RECEIVE_STATUS_FULL) {
+        uint32_t chunk_size = 0;
+        bool is_complete = false;
+        int return_code;
+
+        CHECK(result->chunk_count < TEST_CHUNK_CAPACITY);
+        CHECK(result->output_size < TEST_OUTPUT_CAPACITY);
+
+        return_code = isotp_receive_streaming(link, result->output + result->output_size,
+                                              TEST_OUTPUT_CAPACITY - result->output_size, &chunk_size, &is_complete);
+        CHECK(return_code == ISOTP_RET_OK);
+        result->chunk_sizes[result->chunk_count++] = chunk_size;
+        result->output_size += chunk_size;
+        if (is_complete) { ++result->complete_count; }
+    }
+
+    return 0;
+}
+
+static int run_stream_transfer(uint32_t payload_size, uint32_t receive_buffer_size, StreamResult* result) {
+    TestLink test_link;
+    uint8_t payload[TEST_OUTPUT_CAPACITY];
+    uint32_t offset;
+    uint8_t sequence_number = 1;
+
+    CHECK(payload_size <= sizeof(payload));
+    CHECK(receive_buffer_size <= sizeof(test_link.receive_buffer));
+
+    fill_payload(payload, payload_size);
+    (void)memset(result, 0, sizeof(*result));
+    init_test_link(&test_link, receive_buffer_size);
+
+    offset = inject_first_frame(&test_link.link, payload, payload_size);
+    CHECK(drain_available_chunks(&test_link.link, result) == 0);
+
+    while (offset < payload_size) {
+        CHECK(test_link.link.receive_status == ISOTP_RECEIVE_STATUS_INPROGRESS);
+        inject_consecutive_frame(&test_link.link, payload, payload_size, &offset, &sequence_number);
+        CHECK(drain_available_chunks(&test_link.link, result) == 0);
+    }
+
+    CHECK(result->output_size == payload_size);
+    CHECK(memcmp(result->output, payload, payload_size) == 0);
+    CHECK(result->complete_count == 1u);
+    CHECK(test_link.link.receive_status == ISOTP_RECEIVE_STATUS_IDLE);
+    return 0;
+}
+
+static int check_flow_control_frames(uint8_t expected_block_size, size_t expected_count) {
+    size_t index;
+
+    CHECK(isotp_mock_can_frame_count() == expected_count);
+    for (index = 0; index < expected_count; ++index) {
+        const IsoTpMockCanFrame* frame = isotp_mock_can_frame(index);
+
+        CHECK(frame != NULL);
+        CHECK(frame->arbitration_id == 0x731u);
+        CHECK(frame->size == 8u);
+        CHECK((frame->data[0] >> 4) == ISOTP_PCI_TYPE_FLOW_CONTROL_FRAME);
+        CHECK((frame->data[0] & 0x0fu) == PCI_FLOW_STATUS_CONTINUE);
+        CHECK(frame->data[1] == expected_block_size);
+    }
+    return 0;
+}
+
+static int test_single_frame(void) {
+    TestLink test_link;
+    uint8_t frame[] = {0x03, 0xa1, 0xb2, 0xc3};
+    uint8_t output[8] = {0};
+    uint32_t output_size = 0;
+    bool is_complete = false;
+
+    init_test_link(&test_link, sizeof(test_link.receive_buffer));
+    isotp_on_can_message(&test_link.link, frame, sizeof(frame));
+
+    CHECK(isotp_receive_streaming(&test_link.link, output, sizeof(output), &output_size, &is_complete) == ISOTP_RET_OK);
+    CHECK(output_size == 3u);
+    CHECK(is_complete);
+    CHECK(memcmp(output, frame + 1, output_size) == 0);
+    CHECK(isotp_mock_can_frame_count() == 0u);
+    return 0;
+}
+
+static int test_multiframe_fitting_receive_buffer(void) {
+    TestLink test_link;
+    uint8_t payload[20];
+    uint8_t output[20] = {0};
+    uint32_t output_size = 0;
+    uint32_t offset;
+    uint8_t sequence_number = 1;
+    bool is_complete = false;
+
+    fill_payload(payload, sizeof(payload));
+    init_test_link(&test_link, 32);
+    offset = inject_first_frame(&test_link.link, payload, sizeof(payload));
+    CHECK(check_flow_control_frames(ISO_TP_DEFAULT_BLOCK_SIZE, 1) == 0);
+
+    while (offset < sizeof(payload)) { inject_consecutive_frame(&test_link.link, payload, sizeof(payload), &offset, &sequence_number); }
+
+    CHECK(isotp_receive_streaming(&test_link.link, output, sizeof(output), &output_size, &is_complete) == ISOTP_RET_OK);
+    CHECK(output_size == sizeof(payload));
+    CHECK(is_complete);
+    CHECK(memcmp(output, payload, sizeof(payload)) == 0);
+    return 0;
+}
+
+static int test_short_stream_chunk_boundaries(void) {
+    StreamResult result;
+
+    CHECK(run_stream_transfer(25, 8, &result) == 0);
+    CHECK(result.chunk_count == 4u);
+    CHECK(result.chunk_sizes[0] == 8u);
+    CHECK(result.chunk_sizes[1] == 8u);
+    CHECK(result.chunk_sizes[2] == 8u);
+    CHECK(result.chunk_sizes[3] == 1u);
+    CHECK(check_flow_control_frames(1, 3) == 0);
+    return 0;
+}
+
+static int test_one_byte_receive_buffer(void) {
+    StreamResult result;
+    size_t index;
+
+    CHECK(run_stream_transfer(20, 1, &result) == 0);
+    CHECK(result.chunk_count == 20u);
+    for (index = 0; index < result.chunk_count; ++index) { CHECK(result.chunk_sizes[index] == 1u); }
+    CHECK(check_flow_control_frames(1, 2) == 0);
+    return 0;
+}
+
+static int test_long_2016_message(void) {
+    StreamResult result;
+
+    CHECK(run_stream_transfer(4100, 13, &result) == 0);
+    CHECK(result.chunk_count == 316u);
+    CHECK(result.chunk_sizes[0] == 13u);
+    CHECK(result.chunk_sizes[result.chunk_count - 1u] == 5u);
+    CHECK(check_flow_control_frames(1, 586) == 0);
+    return 0;
+}
+
+static int test_destination_too_small_does_not_consume_chunk(void) {
+    TestLink test_link;
+    uint8_t payload[20];
+    uint8_t output[8] = {0};
+    uint32_t output_size = 1234;
+    uint32_t offset;
+    uint8_t sequence_number = 1;
+    bool is_complete = true;
+
+    fill_payload(payload, sizeof(payload));
+    init_test_link(&test_link, 8);
+    offset = inject_first_frame(&test_link.link, payload, sizeof(payload));
+    inject_consecutive_frame(&test_link.link, payload, sizeof(payload), &offset, &sequence_number);
+    CHECK(test_link.link.receive_status == ISOTP_RECEIVE_STATUS_FULL);
+
+    CHECK(isotp_receive_streaming(&test_link.link, output, 7, &output_size, &is_complete) == ISOTP_RET_NOSPACE);
+    CHECK(test_link.link.receive_status == ISOTP_RECEIVE_STATUS_FULL);
+    CHECK(output_size == 1234u);
+    CHECK(is_complete);
+    CHECK(isotp_mock_can_frame_count() == 1u);
+
+    CHECK(isotp_receive_streaming(&test_link.link, output, sizeof(output), &output_size, &is_complete) == ISOTP_RET_OK);
+    CHECK(output_size == sizeof(output));
+    CHECK(!is_complete);
+    CHECK(memcmp(output, payload, sizeof(output)) == 0);
+    CHECK(isotp_mock_can_frame_count() == 2u);
+    return 0;
+}
+
+static int test_errors_and_legacy_api(void) {
+    TestLink test_link;
+    uint8_t payload[20];
+    uint8_t output[32] = {0};
+    uint32_t output_size = 0;
+    uint32_t offset;
+    uint8_t sequence_number = 1;
+    bool is_complete = false;
+
+    fill_payload(payload, sizeof(payload));
+    init_test_link(&test_link, 8);
+
+    CHECK(isotp_receive_streaming(&test_link.link, output, sizeof(output), &output_size, &is_complete) == ISOTP_RET_NO_DATA);
+    CHECK(isotp_receive_streaming(NULL, output, sizeof(output), &output_size, &is_complete) == ISOTP_RET_ERROR);
+    CHECK(isotp_receive_streaming(&test_link.link, NULL, sizeof(output), &output_size, &is_complete) == ISOTP_RET_ERROR);
+    CHECK(isotp_receive_streaming(&test_link.link, output, sizeof(output), NULL, &is_complete) == ISOTP_RET_ERROR);
+    CHECK(isotp_receive_streaming(&test_link.link, output, sizeof(output), &output_size, NULL) == ISOTP_RET_ERROR);
+
+    offset = inject_first_frame(&test_link.link, payload, sizeof(payload));
+    inject_consecutive_frame(&test_link.link, payload, sizeof(payload), &offset, &sequence_number);
+    CHECK(isotp_receive(&test_link.link, output, sizeof(output), &output_size) == ISOTP_RET_ERROR);
+    CHECK(test_link.link.receive_status == ISOTP_RECEIVE_STATUS_FULL);
+    return 0;
+}
+
+static int test_receive_callback_coexists_with_streaming(void) {
+    TestLink test_link;
+    StreamResult result = {0};
+    uint8_t single_frame[] = {0x03, 0xde, 0xad, 0x42};
+    uint8_t payload[20];
+    uint32_t offset;
+    uint8_t sequence_number = 1;
+    int callback_argument = 17;
+
+    fill_payload(payload, sizeof(payload));
+    init_test_link(&test_link, 8);
+    isotp_set_rx_done_cb(&test_link.link, isotp_mock_rx_done_cb, &callback_argument);
+
+    isotp_on_can_message(&test_link.link, single_frame, sizeof(single_frame));
+    CHECK(isotp_mock_rx_callback_count() == 1u);
+    CHECK(isotp_mock_rx_callback_size() == 3u);
+    CHECK(memcmp(isotp_mock_rx_callback_data(), single_frame + 1, 3) == 0);
+    CHECK(isotp_mock_rx_callback_link() == &test_link.link);
+    CHECK(isotp_mock_rx_callback_arg() == &callback_argument);
+
+    offset = inject_first_frame(&test_link.link, payload, sizeof(payload));
+    inject_consecutive_frame(&test_link.link, payload, sizeof(payload), &offset, &sequence_number);
+    CHECK(isotp_mock_rx_callback_count() == 1u);
+    CHECK(drain_available_chunks(&test_link.link, &result) == 0);
+
+    while (offset < sizeof(payload)) {
+        inject_consecutive_frame(&test_link.link, payload, sizeof(payload), &offset, &sequence_number);
+        CHECK(drain_available_chunks(&test_link.link, &result) == 0);
+    }
+
+    CHECK(result.output_size == sizeof(payload));
+    CHECK(memcmp(result.output, payload, sizeof(payload)) == 0);
+    CHECK(result.complete_count == 1u);
+    CHECK(isotp_mock_rx_callback_count() == 1u);
+    return 0;
+}
+
+static int test_zero_sized_receive_buffer_rejects_stream(void) {
+    TestLink test_link;
+    uint8_t payload[20];
+    const IsoTpMockCanFrame* flow_control;
+
+    fill_payload(payload, sizeof(payload));
+    init_test_link(&test_link, 0);
+    (void)inject_first_frame(&test_link.link, payload, sizeof(payload));
+
+    CHECK(test_link.link.receive_status == ISOTP_RECEIVE_STATUS_IDLE);
+    CHECK(test_link.link.receive_protocol_result == ISOTP_PROTOCOL_RESULT_BUFFER_OVFLW);
+    CHECK(isotp_mock_can_frame_count() == 1u);
+    flow_control = isotp_mock_can_frame(0);
+    CHECK(flow_control != NULL);
+    CHECK((flow_control->data[0] >> 4) == ISOTP_PCI_TYPE_FLOW_CONTROL_FRAME);
+    CHECK((flow_control->data[0] & 0x0fu) == PCI_FLOW_STATUS_OVERFLOW);
+    CHECK(flow_control->data[1] == 0u);
+    CHECK(isotp_mock_debug_count() == 1u);
+    return 0;
+}
+
+static int test_wrong_sequence_number_aborts_stream(void) {
+    TestLink test_link;
+    uint8_t payload[20];
+    uint8_t wrong_frame[8] = {0x22};
+
+    fill_payload(payload, sizeof(payload));
+    (void)memcpy(wrong_frame + 1, payload + 6, 7);
+    init_test_link(&test_link, 8);
+    (void)inject_first_frame(&test_link.link, payload, sizeof(payload));
+    isotp_on_can_message(&test_link.link, wrong_frame, sizeof(wrong_frame));
+
+    CHECK(test_link.link.receive_status == ISOTP_RECEIVE_STATUS_IDLE);
+    CHECK(test_link.link.receive_protocol_result == ISOTP_PROTOCOL_RESULT_WRONG_SN);
+    return 0;
+}
+
+static int test_stream_timeout(void) {
+    TestLink test_link;
+    uint8_t payload[20];
+
+    fill_payload(payload, sizeof(payload));
+    init_test_link(&test_link, 16);
+    isotp_mock_set_time_us(100);
+    (void)inject_first_frame(&test_link.link, payload, sizeof(payload));
+    CHECK(test_link.link.receive_status == ISOTP_RECEIVE_STATUS_INPROGRESS);
+
+    isotp_mock_advance_time_us(ISO_TP_DEFAULT_RESPONSE_TIMEOUT_US + 1u);
+    isotp_poll(&test_link.link);
+    CHECK(test_link.link.receive_status == ISOTP_RECEIVE_STATUS_IDLE);
+    CHECK(test_link.link.receive_protocol_result == ISOTP_PROTOCOL_RESULT_TIMEOUT_CR);
+    return 0;
+}
+
+static int test_malformed_frames(void) {
+    TestLink test_link;
+    uint8_t payload[20];
+    uint8_t short_single_frame[] = {0x03, 0xaa};
+    uint8_t short_first_frame[7] = {0x10, 0x14};
+    uint8_t invalid_first_frame[8] = {0x10, 0x07};
+    uint8_t short_consecutive_frame[] = {0x21, 0xaa};
+
+    fill_payload(payload, sizeof(payload));
+
+    init_test_link(&test_link, 16);
+    isotp_on_can_message(&test_link.link, short_single_frame, sizeof(short_single_frame));
+    CHECK(test_link.link.receive_status == ISOTP_RECEIVE_STATUS_IDLE);
+    CHECK(isotp_mock_debug_count() == 1u);
+
+    init_test_link(&test_link, 16);
+    isotp_on_can_message(&test_link.link, short_first_frame, sizeof(short_first_frame));
+    CHECK(test_link.link.receive_status == ISOTP_RECEIVE_STATUS_IDLE);
+    CHECK(isotp_mock_debug_count() == 1u);
+
+    init_test_link(&test_link, 16);
+    isotp_on_can_message(&test_link.link, invalid_first_frame, sizeof(invalid_first_frame));
+    CHECK(test_link.link.receive_status == ISOTP_RECEIVE_STATUS_IDLE);
+    CHECK(isotp_mock_debug_count() == 1u);
+
+    init_test_link(&test_link, 16);
+    (void)inject_first_frame(&test_link.link, payload, sizeof(payload));
+    isotp_on_can_message(&test_link.link, short_consecutive_frame, sizeof(short_consecutive_frame));
+    CHECK(test_link.link.receive_status == ISOTP_RECEIVE_STATUS_INPROGRESS);
+    CHECK(isotp_mock_debug_count() == 1u);
+    return 0;
+}
+
+typedef int (*TestFunction)(void);
+
+typedef struct TestCase {
+    const char* name;
+    TestFunction function;
+} TestCase;
+
+int main(void) {
+    static const TestCase tests[] = {
+        {"single frame", test_single_frame},
+        {"multi-frame fitting receive buffer", test_multiframe_fitting_receive_buffer},
+        {"short stream chunk boundaries", test_short_stream_chunk_boundaries},
+        {"one-byte receive buffer", test_one_byte_receive_buffer},
+        {"ISO-TP 2016 long message", test_long_2016_message},
+        {"destination too small", test_destination_too_small_does_not_consume_chunk},
+        {"errors and legacy API", test_errors_and_legacy_api},
+        {"receive callback coexistence", test_receive_callback_coexists_with_streaming},
+        {"zero-sized receive buffer", test_zero_sized_receive_buffer_rejects_stream},
+        {"wrong sequence number", test_wrong_sequence_number_aborts_stream},
+        {"stream timeout", test_stream_timeout},
+        {"malformed frames", test_malformed_frames},
+    };
+    size_t index;
+
+    for (index = 0; index < sizeof(tests) / sizeof(tests[0]); ++index) {
+        int return_code = tests[index].function();
+
+        if (return_code != 0) {
+            (void)fprintf(stderr, "FAILED: %s\n", tests[index].name);
+            return return_code;
+        }
+        (void)printf("PASS: %s\n", tests[index].name);
+    }
+
+    return 0;
+}

--- a/vars.mk
+++ b/vars.mk
@@ -31,8 +31,8 @@ CPPSTD := "c++0x"
 ###
 LIB_NAME := "libisotp.so"
 MAJOR_VER := "1"
-MINOR_VER := "6"
-REVISION := "4"
+MINOR_VER := "7"
+REVISION := "0"
 OUTPUT_NAME := $(LIB_NAME).$(MAJOR_VER).$(MINOR_VER).$(REVISION)
 
 ###


### PR DESCRIPTION
  ## Summary

  Adds opt-in streaming support for receiving ISO-TP messages larger than the configured receive buffer.

  Instead of requiring the complete message to fit in RAM, applications can consume buffer-sized chunks through the new `isotp_receive_streaming()` API. This supports use cases such as writing firmware updates directly to flash on memory-constrained devices.

  Closes #60.

  ## Changes

  - Add the `isotpc_ENABLE_STREAMING` CMake option.
  - Add `isotp_receive_streaming()` with an `is_complete` result.
  - Pause and resume the sender through ISO-TP flow control while chunks are consumed.
  - Preserve consecutive-frame data that crosses a receive-buffer boundary.
  - Support ISO 15765-2:2016 long messages larger than 4095 bytes.
  - Allow oversized messages to use streaming polling when receive callbacks are configured.
  - Preserve the existing API and `IsoTpLink` layout when streaming is disabled.
  - Document configuration and usage.
  - Bump the library version to `1.7.0`.

  ## Testing

  Added mocked CAN, timing, debugging, and receive-callback shims with coverage for:

  - Single-frame and regular multi-frame reception
  - Buffer-sized and partial final chunks
  - One-byte receive buffers
  - ISO-TP 2016 long messages
  - Flow-control pause/resume behavior
  - Insufficient output-buffer handling
  - Legacy receive API interaction
  - Receive callback coexistence
  - Zero-sized receive buffers
  - Incorrect sequence numbers
  - Receive timeouts
  - Malformed frames

  The streaming API and streaming first/consecutive-frame handlers have 100% test coverage.

  ## Validation

  - Debug and Release CMake builds
  - CTest suite
  - AddressSanitizer
  - UndefinedBehaviorSanitizer
  - `cppcheck`
  - Version gate
  - Linux and MSVC CI integration

